### PR TITLE
Added/removed/modified file lists

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ notify-webhook is a [git](http://git.or.cz) post-receive hook script
 that posts JSON data to a web hook capable server.
 
 This implements the [GitHub](http://github.com) [Web hooks
-API](http://github.com/guides/post-receive-hooks) as closely as
+API](http://help.github.com/post-receive-hooks/) as closely as
 possible.  It allows arbitrary git repositories to use Web hook
 capable services.
 

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -23,70 +23,70 @@ EMAIL_RE = re.compile("^(.*) <(.*)>$")
 def get_revisions(old, new):
     git = subprocess.Popen(['git', 'rev-list', '--pretty=medium', '%s..%s' % (old, new)], stdout=subprocess.PIPE)
     sections = git.stdout.read().split('\n\n')[:-1]
-
+    
     revisions = []
     s = 0
     while s < len(sections):
-	lines = sections[s].split('\n')
-	    
-	# first line is 'commit HASH\n'
-	props = {'id': lines[0].strip().split(' ')[1]}
-	    
-	# read the header
-	for l in lines[1:]:
-	    key, val = l.split(' ', 1)
-	    props[key[:-1].lower()] = val.strip()
-
-	# read the commit message
-	props['message'] = sections[s+1]
-
-	# use github time format
-	basetime = datetime.strptime(props['date'][:-6], "%a %b %d %H:%M:%S %Y")
-	tzstr = props['date'][-5:]
-	props['date'] = basetime.strftime('%Y-%m-%dT%H:%M:%S') + tzstr
-
-	# split up author
-	m = EMAIL_RE.match(props['author'])
-	if m:
-	    props['name'] = m.group(1)
-	    props['email'] = m.group(2)
-	else:
-	    props['name'] = 'unknown'
-	    props['email'] = 'unknown'
-	del props['author']
-	
-	revisions.append(props)
-	s += 2
-	
+        lines = sections[s].split('\n')
+        
+        # first line is 'commit HASH\n'
+        props = {'id': lines[0].strip().split(' ')[1]}
+        
+        # read the header
+        for l in lines[1:]:
+            key, val = l.split(' ', 1)
+            props[key[:-1].lower()] = val.strip()
+        
+        # read the commit message
+        props['message'] = sections[s+1]
+        
+        # use github time format
+        basetime = datetime.strptime(props['date'][:-6], "%a %b %d %H:%M:%S %Y")
+        tzstr = props['date'][-5:]
+        props['date'] = basetime.strftime('%Y-%m-%dT%H:%M:%S') + tzstr
+        
+        # split up author
+        m = EMAIL_RE.match(props['author'])
+        if m:
+            props['name'] = m.group(1)
+            props['email'] = m.group(2)
+        else:
+            props['name'] = 'unknown'
+            props['email'] = 'unknown'
+        del props['author']
+        
+        revisions.append(props)
+        s += 2
+    
     return revisions
 
 def make_json(old, new, ref):
     data = {
-	'before': old,
-	'after': new,
-	'ref': ref,
-	'repository': {
-	    'url': REPO_URL,
-	    'name': REPO_NAME,
-	    'description': REPO_DESC,
-	    'owner': {
-		'name': REPO_OWNER_NAME,
-		'email': REPO_OWNER_EMAIL
-		}
-	    }
-	}
-
+        'before': old,
+        'after': new,
+        'ref': ref,
+        'repository': {
+            'url': REPO_URL,
+            'name': REPO_NAME,
+            'description': REPO_DESC,
+            'owner': {
+                'name': REPO_OWNER_NAME,
+                'email': REPO_OWNER_EMAIL
+                }
+            }
+        }
+    
     revisions = get_revisions(old, new)
     commits = []
     for r in revisions:
-	commits.append({'id': r['id'],
-			'author': {'name': r['name'], 'email': r['email']},
-			'url': COMMIT_URL % r['id'],
-			'message': r['message'],
-			'timestamp': r['date']
-			})
+        commits.append({'id': r['id'],
+                        'author': {'name': r['name'], 'email': r['email']},
+                        'url': COMMIT_URL % r['id'],
+                        'message': r['message'],
+                        'timestamp': r['date']
+                        })
     data['commits'] = commits
-
+    
     return json.dumps(data)
 
 
@@ -94,7 +94,6 @@ def post(url, data):
     u = urllib2.urlopen(POST_URL, urllib.urlencode({'payload': data}))
     u.read()
     u.close()
-
 
 if __name__ == '__main__':
     for line in sys.stdin.xreadlines():

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -11,6 +11,7 @@ import simplejson as json
 POST_URL = 'http://example.com'
 REPO_URL = 'http://example.com'
 COMMIT_URL = r'http://example.com/commit/%s'
+COMPARE_URL = r'http://exmaple.com/compare/%s..%s'
 REPO_NAME = 'gitrepo'
 REPO_OWNER_NAME = 'Git U. Some'
 REPO_OWNER_EMAIL = 'git@example.com'
@@ -91,6 +92,7 @@ def make_json(old, new, ref):
         'before': old,
         'after': new,
         'ref': ref,
+        'compare': COMPARE_URL % (old, new),
         'repository': {
             'url': REPO_URL,
             'name': REPO_NAME,

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -32,10 +32,11 @@ def get_revisions(old, new):
         # first line is 'commit HASH\n'
         props = {'id': lines[0].strip().split(' ')[1], 'added': [], 'removed': [], 'modified': []}
         
-        # Call git diff-tree and get the added/moded/removed files
+        # call git diff-tree and get the file changes
         git_difftree = subprocess.Popen(['git', 'diff-tree', '-r', '-C', '%s' % props['id']], stdout=subprocess.PIPE)
         output = git_difftree.stdout.read()
         
+        # sort the changes into the added/modified/removed lists
         for i in DIFF_TREE_RE.finditer(output):
             item = i.groupdict()
             if item['status'] == 'A':      # addition of a file
@@ -51,9 +52,11 @@ def get_revisions(old, new):
                 props['added'].append(item['file2'])
             elif item['status'] == 'T':    # change in the type of the file
                 props['modified'].append(item['file1'])
-            else: # Covers U (file is unmerged) and X ("unknown" change type, usually an error
-                pass # We shouldn't be seeing U. When we get X be do not know what actually happened
-                     # so it's safest just to ignore it.
+            else: # Covers U (file is unmerged)
+                  #    and X ("unknown" change type, usually an error)
+                pass # When we get X, we do not know what actually happened so
+                     # it's safest just to ignore it. We shouldn't be seeing U
+                     # anyway, so we can ignore that too.
         
         # read the header
         for l in lines[1:]:


### PR DESCRIPTION
I added the file lists for added/removed/modified files for each commit to the outputted JSON, matching the current GitHub [post receive hook](http://help.github.com/post-receive-hooks/) format. Doing so added an extra git call for each commit (to list what the file changes were).

I also updated the link in the readme (commit Ashfire908@261e7574195d3382f6f5d56edd8a1a9eb0223fbc) and standardized the indentation from mixed tabs and spaces to 4 spaces (commit Ashfire908@9cee9b91b695daa9426284768e03db87aea2547e).