### PR TITLE
Fixed issue #4 and added support for head_commit and base_ref

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -1,2 +1,3 @@
  - [Jack Moffitt](http://metajack.im/)
  - [Benjie Gillam](http://www.benjiegillam.com/)
+ - [Vojta Grec](http://www.easysoftware.cz/)

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -123,13 +123,13 @@ def make_json(old, new, ref):
 
     return json.dumps(data)
 
-
 def post(url, data):
-    u = urllib2.urlopen(POST_URL, urllib.urlencode({'payload': data}))
-    u.read()
-    u.close()
-
-
+    try:
+        u = urllib2.urlopen(POST_URL, urllib.urlencode({'payload': data}))
+        u.read()
+        u.close()
+    except urllib2.HTTPError as error:
+        print "POST to " + POST_URL + " returned error code " + str(error.code) + "."
 
 if __name__ == '__main__':
     for line in sys.stdin.xreadlines():


### PR DESCRIPTION
I found notify-wehbook while implementing some git-powered build system in my company. I'm a Python newbie but I did my best to implement features needed to mock GitHub behavior as closely as possible:
* *Fixed issue #4* - when "old" hash is all zeroes, `git rev-list` complains about it. Now it returns empty array for `commits`.
* *Implemented `head_commit` support* - it returns the last commit on the ref.
* *Implemented `base_ref` support* - it tries to find f.e. a branch, on which a tagged commit was made, and uses this for `base_ref`.

I'm open to any request for improvement.

