### PR TITLE
Fix _git_config by spliting raw_config at \0 or \n

### DIFF
--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -26,7 +26,7 @@ def grouper(n, iterable, padvalue=None):
 
 def _git_config():
     raw_config = git(['config', '-l', '-z'])
-    return OrderedDict(grouper(2, raw_config.split("\0")))
+    return OrderedDict(grouper(2, re.compile("[\0\n]").split(raw_config)))
 
 GIT_CONFIG = _git_config()
 


### PR DESCRIPTION
Hi,

My git config variables aren't being correctly read unless I'm doing something wrong. But, I get the values below.

`OrderedDict([('user.name\nRafael Xavier de Souza', 'user.email\nrxaviers@gmail.com'), ('core.repositoryformatversion\n0', 'core.filemode\ntrue'), ('core.bare\ntrue', 'meta.url\nmyapp'), ('meta.ownername\nrxaviers', 'meta.owneremail\n'), ('hooks.webhookurl\nhttp://localhost:8000', '')])`

This commit fix it by spliting `\n` as well.