### PR TITLE
POST data should be bytes or an iterable of bytes. It cannot be of type str

### DIFF
--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -275,7 +275,7 @@ def post(url, data):
     if POST_CONTENTTYPE == 'application/json':
         postdata = data
     elif POST_CONTENTTYPE == 'application/x-www-form-urlencoded':
-        postdata = urllib.parse.urlencode({'payload': data})
+        postdata = urllib.parse.urlencode({'payload': data}).encode('UTF-8')
     if POST_SECRET_TOKEN is not None:
         import hmac
         import hashlib


### PR DESCRIPTION
I have to `.encode('UTF-8')` before posting or I get the following error:

    <urllib.request.OpenerDirector object at 0x7f03aba53518>
    Traceback (most recent call last):
      File "hooks/post-receive", line 314, in <module>
        post(POST_URL, data)
      File "hooks/post-receive", line 302, in post
        u = opener.open(request)
      File "/usr/lib/python3.4/urllib/request.py", line 453, in open
        req = meth(req)
      File "/usr/lib/python3.4/urllib/request.py", line 1163, in do_request_
        raise TypeError(msg)
    TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.

- [ ] Worth checking if this same fix applies to https://github.com/metajack/notify-webhook/blob/98b98039f1aeaafd1f122aaf460965f300202e30/notify-webhook.py#L276