### PR TITLE
Add configuration for multiple webhook URLs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,7 +48,24 @@ The URL to the webhook consumer - the commit details will be POSTed
 here.
 
 Defaults to `None` **which will echo the JSON data instead of sending
-it**.
+it** (unless the `hooks.webhookurls` configuration is set).
+
+#### hooks.webhookurls
+
+A list of URLs to different webhook consumers - the commit details will
+be POSTed to each of them in the order they arrive (if hooks.webhookurl
+is set, the commit details will be POSTed to that URL first).
+
+The value is parsed like a csv file so each URL is separated by a comma
+or a newline (or a combination of the two). URLs with a comma in them
+can be wrapped in quotation marks.
+
+An example of value with two URLS:
+
+    git config hooks.webhookurls 'http://example.com/hook,"http://other.example.com/hook,with,comma"'
+
+Defaults to `None` **which will echo the JSON data instead of sending
+it** (unless the `hooks.webhookurl` configuration is set).
 
 #### meta.ownername / meta.owneremail
 Details about the repository owner.

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -5,6 +5,8 @@ import urllib.request, urllib.parse, urllib.error
 import re
 import os
 import subprocess
+import csv
+import io
 from datetime import datetime
 import simplejson as json
 from itertools import chain, repeat
@@ -61,6 +63,7 @@ def extract_name_email(s):
     return (name, email)
 
 POST_URL = get_config('hooks.webhookurl')
+POST_URLS = get_config('hooks.webhookurls')
 POST_USER = get_config('hooks.authuser')
 POST_PASS = get_config('hooks.authpass')
 POST_REALM = get_config('hooks.authrealm')
@@ -310,8 +313,15 @@ if __name__ == '__main__':
     for line in sys.stdin:
         old, new, ref = line.strip().split(' ')
         data = make_json(old, new, ref)
-        if POST_URL:
-            post(POST_URL, data)
+        if POST_URL or POST_URLS:
+            if POST_URL:
+                post(POST_URL, data)
+            if POST_URLS:
+                urls = io.StringIO(POST_URLS)
+                rows = csv.reader(urls)
+                for row in rows:
+                    for url in row:
+                        post(url.strip(), data)
         else:
             print(data)
 

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -303,7 +303,7 @@ def post(url, data):
         u.read()
         u.close()
     except urllib.error.HTTPError as error:
-        errmsg = "POST to %s returned error code %s." % (POST_URL, str(error.code))
+        errmsg = "POST to %s returned error code %s." % (url, str(error.code))
         print(errmsg, file=sys.stderr)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add the configuration setting hooks.webhookurls to allow POSTing to multiple webhooks instead of just a single one. The previous hooks.webhookurl can still be used and the two can even be combined
where the hooks.webhookurl is the first webhook and the ones in hooks.webhookurls are secondary.
    
The reason the splitting isn't added to the hooks.webhookurl is for backwards compatibility where hooks.webhookurl might have a URL that includes a comma which would then be split incorrectly.