### PR TITLE
Fix bug- on first ever push returns non-empty commits list

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -4,3 +4,4 @@
  - [Robin H. Johnson](http://www.orbis-terrarum.net/)
  - [Nguyen Tien Si](info@nguyentiensi.com)
  - [Andrew Hampe](https://github.com/Ashfire908)
+ - [Omer Dagan](https://github.com/mromerdagan)

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -110,9 +110,6 @@ if REPO_OWNER_NAME is None or REPO_OWNER_EMAIL is None:
 
 def get_revisions(old, new, head_commit=False):
     if re.match("^0+$", old):
-        if not head_commit:
-            return []
-
         commit_range = '%s..%s' % (EMPTY_TREE_HASH, new)
     else:
         commit_range = '%s..%s' % (old, new)

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -9,7 +9,6 @@ import csv
 import io
 from datetime import datetime
 import simplejson as json
-from itertools import chain, repeat
 from collections import OrderedDict
 
 EMAIL_RE = re.compile("^\"?(.*)\"? <(.*)>$")
@@ -18,7 +17,7 @@ EMPTY_TREE_HASH = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
 def git(args):
     args = ['git'] + args
-    git = subprocess.Popen(args, stdout = subprocess.PIPE)
+    git = subprocess.Popen(args, stdout=subprocess.PIPE)
     details = git.stdout.read()
     details = details.decode('utf-8', 'replace').strip()
     return details
@@ -100,7 +99,7 @@ if gitweb_owner is not None and REPO_OWNER_NAME is None and REPO_OWNER_EMAIL is 
 # Fallback to the repo
 if REPO_OWNER_NAME is None or REPO_OWNER_EMAIL is None:
     # You cannot include -n1 because it is processed before --reverse
-    logmsg = git(['log','--reverse','--format=%an%x09%ae']).split("\n")[0]
+    logmsg = git(['log', '--reverse', '--format=%an%x09%ae']).split("\n")[0]
     # These will never be null
     (name, email) = logmsg.split("\t")
     if REPO_OWNER_NAME is None:


### PR DESCRIPTION
Before, on first ever push, get_revisions returned empty commit list if
wasn't called with head_commit=True. This lead to json with commits=[]
on first ever push, no matter what was the push content.
After fix, commits contains the relevant content.