### PR TITLE
Fix get_repo_name() for non-bare repos

### DIFF
--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -44,7 +44,7 @@ def get_repo_name():
             name = name[:-4]
         return name
     else:
-        return os.path.basename(os.path.dirname(os.getcwd()))
+        return os.path.basename(os.getcwd())
 
 def extract_name_email(s):
     p = re.compile(EMAIL_RE)


### PR DESCRIPTION
In non-base repos, repo name is assumed to be the repo dir name.
In prvious implementation it got the parent dir name, so if for example
if the repo is located at:

	/srv/git/myrepo

The previous imlpementation would have returned 'git' as the repo name,
rather than 'myrepo'