### PR TITLE
Remove simplejson

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ sends commit notifications to XMPP group chat rooms.
 
 ## Dependencies
 
-* [simplejson](http://pypi.python.org/pypi/simplejson)
+* [Python 3.6+](http://python.org/downloads)
 
 ## Usage
 ### Installation & Configuration (manual)

--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 import urllib.error
 import urllib.parse
 import urllib.request
-import simplejson as json
+import json
 
 EMAIL_RE = re.compile(r"^(\"?)(?P<name>.*)\1\s+<(?P<email>.*)>$")
 


### PR DESCRIPTION
Changed simplejson to standard module: 'json'. This worked well for me using Python 3.6.
Updated Dependencies section accordingly.