### PR TITLE
set correct groups indices to extract author name and email

### DIFF
--- a/notify-webhook.py
+++ b/notify-webhook.py
@@ -228,8 +228,8 @@ def get_revisions(old, new, head_commit=False):
         # split up author
         m = EMAIL_RE.match(props['author'])
         if m:
-            props['name'] = m.group(1)
-            props['email'] = m.group(2)
+            props['name'] = m.group(2)
+            props['email'] = m.group(3)
         else:
             props['name'] = 'unknown'
             props['email'] = 'unknown'


### PR DESCRIPTION
Hi,

I stumbled upon your script and found it very useful to integrate local hosted repositories with my online time tracking which is compatible with github style webhooks, so thanks for your work on that!!

I did notice that in the webhook json, the author name was empty and the mail field contained the author name.

```json
	"commits": [
		{
			"id": "880d1cbc6dcdd811c5be441896b37e6192cd1d88",
			"author": {
				"name": "",
				"email": "Stijn Mathysen"
			},
			"url": null,
```

I'm no expert in python, but I noticed you use regional expressions to extract both name and email;

```
            props['name'] = m.group(1)
            props['email'] = m.group(2)
```

```
EMAIL_RE = re.compile(r"^(\"?)(?P<name>.*)\1\s+<(?P<email>.*)>$")
```

Your regional expression however, defines three groups, the first being (optional) quotes, then the name and then the e-mail.

Taking the initial group into account, and moving the indexes solved my issue and now both author name and e-mail come through.

This pull requests fixes that index offset issue. I hope it's useful to you.


Kind regards,

Stijn

